### PR TITLE
Generalise Oracle 12.1 RDS Engine Versions

### DIFF
--- a/groups/rds/profiles/heritage-live-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-live-eu-west-2/vars
@@ -21,7 +21,7 @@ performance_insights_enabled = true
 
 # RDS Engine settings
 major_engine_version       = "12.1"
-engine_version             = "12.1.0.2.v25"
+engine_version             = "12.1"
 license_model              = "license-included"
 auto_minor_version_upgrade = true
 

--- a/groups/rds/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-staging-eu-west-2/vars
@@ -21,7 +21,7 @@ performance_insights_enabled = false
 
 # RDS Engine settings
 major_engine_version       = "12.1"
-engine_version             = "12.1.0.2.v25"
+engine_version             = "12.1"
 license_model              = "license-included"
 auto_minor_version_upgrade = true
 


### PR DESCRIPTION
Generalised Oracle 12.1 RDS engine versions to their major versions to prevent code/state inconsistencies caused when an automatic minor version upgrade is applied.

Versions should only be specified to the minor level when automatic upgrades are not enabled.