### PR TITLE
Enable RDS alarm actions in Live

### DIFF
--- a/groups/rds/profiles/heritage-live-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-live-eu-west-2/vars
@@ -107,6 +107,6 @@ parameter_group_settings = [
 ]
 
 ## CloudWatch Alarms
-alarm_actions_enabled  = false
+alarm_actions_enabled  = true
 alarm_topic_name       = "Email_Alerts"
 alarm_topic_name_ooh   = "Phonecall_Alerts"


### PR DESCRIPTION
Enabled `alarm_actions` in Live for RDS alarms