### PR TITLE
Update Oracle Alarms

### DIFF
--- a/groups/rds/rds.tf
+++ b/groups/rds/rds.tf
@@ -141,11 +141,12 @@ module "rds_start_stop_schedule" {
 }
 
 module "rds_cloudwatch_alarms" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/rds_cloudwatch_alarms?ref=tags/1.0.167"
+  source = "git@github.com:companieshouse/terraform-modules//aws/oracledb_cloudwatch_alarms?ref=tags/1.0.173"
 
-  rds_instance_id        = module.smartview_rds.this_db_instance_id
-  rds_instance_shortname = upper(var.name)
+  db_instance_id         = module.smartview_rds.this_db_instance_id
+  db_instance_shortname  = upper(var.name)
   alarm_actions_enabled  = var.alarm_actions_enabled
+  alarm_name_prefix      = "Oracle RDS"
   alarm_topic_name       = var.alarm_topic_name
   alarm_topic_name_ooh   = var.alarm_topic_name_ooh
 }


### PR DESCRIPTION
Updated existing RDS alarms module to use updated terraform module path and version
Updated variable names to match updated module requirements
Set `alarm_name_prefix` appropriately