### PR TITLE
Per-profile RDS Options

### DIFF
--- a/groups/rds/profiles/heritage-live-eu-west-2/vars
+++ b/groups/rds/profiles/heritage-live-eu-west-2/vars
@@ -110,6 +110,31 @@ parameter_group_settings = [
     },
 ]
 
+option_group_settings = [
+  {
+    option_name = "JVM"
+  },
+  {
+    option_name = "SQLT"
+    version     = "2018-07-25.v1"
+    option_settings = [
+      {
+        name  = "LICENSE_PACK"
+        value = "N"
+      },
+    ]
+  },
+  {
+    option_name = "Timezone"
+    option_settings = [
+      {
+        name  = "TIME_ZONE"
+        value = "Europe/London"
+      },
+    ]
+  }
+]
+
 ## CloudWatch Alarms
 alarm_actions_enabled  = true
 alarm_topic_name       = "Email_Alerts"

--- a/groups/rds/rds.tf
+++ b/groups/rds/rds.tf
@@ -86,35 +86,13 @@ module "smartview_rds" {
 
   parameters = var.parameter_group_settings
 
-  options = [
+  options = concat([
     {
       option_name                    = "OEM"
       port                           = "5500"
       vpc_security_group_memberships = [module.rds_security_group.this_security_group_id]
-    },
-    {
-      option_name = "JVM"
-    },
-    {
-      option_name = "SQLT"
-      version     = "2018-07-25.v1"
-      option_settings = [
-        {
-          name  = "LICENSE_PACK"
-          value = "N"
-        },
-      ]
-    },
-    {
-      option_name = "Timezone"
-      option_settings = [
-        {
-          name  = "TIME_ZONE"
-          value = "Europe/London"
-        },
-      ]
     }
-  ]
+  ], var.option_group_settings)
 
   timeouts = {
     "create" : "80m",

--- a/groups/rds/variables.tf
+++ b/groups/rds/variables.tf
@@ -74,6 +74,11 @@ variable "parameter_group_settings" {
   description = "A list of parameters that will be set in the RDS instance parameter group"
 }
 
+variable "option_group_settings" {
+  type        = any
+  description = "A list of options that will be set in the RDS instance option group"
+}
+
 variable "rds_onpremise_access" {
   type        = list(string)
   description = "A list of CIDR ranges or IPs to allow access from"


### PR DESCRIPTION
Moved RDS options in to vars to allow for per-profile changes
Updated rds.tf to concatenate standard OEM option with profile options